### PR TITLE
Remove `Revise` and adapt range type in `range()` and `slider()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.1.0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 
 [compat]
 DataFrames = "0.21"
 Genie = "1"
 JSON = "0.21"
-Revise = "2"
 Stipple = "0.2"
 julia = "1"
 

--- a/src/Badge.jl
+++ b/src/Badge.jl
@@ -1,7 +1,5 @@
 module Badge
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Banner.jl
+++ b/src/Banner.jl
@@ -1,7 +1,5 @@
 module Banner
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/BigNumber.jl
+++ b/src/BigNumber.jl
@@ -1,7 +1,5 @@
 module BigNumber
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Button.jl
+++ b/src/Button.jl
@@ -1,7 +1,5 @@
 module Button
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Card.jl
+++ b/src/Card.jl
@@ -1,7 +1,5 @@
 module Card
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Checkbox.jl
+++ b/src/Checkbox.jl
@@ -1,7 +1,5 @@
 module Checkbox
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Chip.jl
+++ b/src/Chip.jl
@@ -1,7 +1,5 @@
 module Chip
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Dashboard.jl
+++ b/src/Dashboard.jl
@@ -1,7 +1,5 @@
 module Dashboard
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Dialog.jl
+++ b/src/Dialog.jl
@@ -1,7 +1,5 @@
 module Dialog
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Form.jl
+++ b/src/Form.jl
@@ -1,7 +1,5 @@
 module Form
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/FormInput.jl
+++ b/src/FormInput.jl
@@ -1,7 +1,5 @@
 module FormInput
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 

--- a/src/Heading.jl
+++ b/src/Heading.jl
@@ -1,7 +1,5 @@
 module Heading
 
-using Revise
-
 import Genie, Stipple
 
 export heading

--- a/src/Icon.jl
+++ b/src/Icon.jl
@@ -1,7 +1,5 @@
 module Icon
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/List.jl
+++ b/src/List.jl
@@ -1,7 +1,5 @@
 module List
 
-using Revise
-
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element
 

--- a/src/Radio.jl
+++ b/src/Radio.jl
@@ -1,7 +1,5 @@
 module Radio
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 

--- a/src/Range.jl
+++ b/src/Range.jl
@@ -1,7 +1,5 @@
 module Range
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 

--- a/src/Range.jl
+++ b/src/Range.jl
@@ -15,7 +15,7 @@ Base.@kwdef mutable struct RangeData{T}
   range::UnitRange{T}
 end
 
-function range( range::StepRange,
+function range( range::AbstractRange{T} where T <: Real,
                 fieldname::Union{Symbol,Nothing},
                 args...;
                 labelalways::Bool = false,
@@ -30,7 +30,7 @@ function range( range::StepRange,
                 kwargs...)
 
   k = (Symbol(":min"), Symbol(":max"), Symbol(":step"))
-  v = Any[range.start, range.stop, range.step]
+  v = Any[first(range), last(range), step(range)]
 
   if fieldname !== nothing
     k = (k..., Symbol("v-model"))
@@ -87,7 +87,7 @@ function range( range::StepRange,
   end
 end
 
-function slider(range::StepRange,
+function slider(range::AbstractRange{T} where T <: Real,
                 fieldname::Symbol,
                 args...;
                 labelalways::Bool = false,
@@ -99,7 +99,7 @@ function slider(range::StepRange,
                 kwargs...)
 
   k = (Symbol(":min"), Symbol(":max"), Symbol(":step"))
-  v = Any[range.start, range.stop, range.step]
+  v = Any[first(range), last(range), step(range)]
 
   if fieldname !== nothing
     k = (k..., Symbol("v-model"))

--- a/src/Select.jl
+++ b/src/Select.jl
@@ -1,7 +1,5 @@
 module Select
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, select, template
 

--- a/src/Separator.jl
+++ b/src/Separator.jl
@@ -1,7 +1,5 @@
 module Separator
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -1,7 +1,5 @@
 module Space
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -1,7 +1,5 @@
 module StippleUI
 
-using Revise
-
 import Genie
 import Stipple
 

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -1,7 +1,5 @@
 module Table
 
-using Revise
-
 import DataFrames, JSON
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, table, template

--- a/src/Toggle.jl
+++ b/src/Toggle.jl
@@ -1,7 +1,5 @@
 module Toggle
 
-using Revise
-
 import Genie, Stipple
 import Genie.Renderer.Html: HTMLString, normal_element, template
 


### PR DESCRIPTION
A discussed in [Stipple.jl](https://github.com/GenieFramework/Stipple.jl/issues/5), I propose to remove `Revise` from Stipple and its child packages.
Additionally, I have modified `range()` and `slider()` to work with any kind of real-valued range. (The current implementation with type `StepRange` does not cover ranges of type 1.0:0.1:10.0)