### PR TITLE
API: '@' and '-' in keywords

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -88,6 +88,16 @@ function attributes(kwargs::Vector{X},
       k = mappings[string(k)]
     end
 
+    if startswith(String(k), "at_")
+      k = Symbol("@" * String(k)[4:end])
+    elseif startswith(String(k), "q_")
+      k = Symbol("@" * String(k)[3:end])
+    end
+
+    if contains(string(k), "_")
+      k = replace(string(k), "_" => "-")
+    end
+
     attr_key = string((isa(v, Symbol) && ! startswith(string(k), ":") && ! startswith(string(k), "v-") ? ":" : ""), "$k") |> Symbol
     attr_val = isa(v, Symbol) && ! startswith(string(k), ":") ? Stipple.julia_to_vue(v) : v
 


### PR DESCRIPTION
I have two proposals to mnake which deal with the keyword API:
- support of the '@' character
- automatic replacement of "_" by "-"

Why:

Quasar makes heavy use of the '@' character to bind functions to events. As Julia doesn't support the '@' character in keywords there is only quite a verbose workaround:

```Dict(R"@click" => "alert = true")...```, e.g. to include a button you would do

```
StippleUI.Button.button("Press me"; color = "secondary", loading = @data("button1"), Dict(R"@click" => "button1 = true")...)
```

I propose two methods to make the call cleaner:
- replace "at_" at the beginning of a keyword by '@' 
- replace "q_" at the beginning of a keyword by '@' 

which would then read:

```
StippleUI.Button.button("Press me"; color = "secondary", loading = @data("button1"), "at_click" = "button1 = true")
StippleUI.Button.button("Press me"; color = "secondary", loading = @data("button1"), "q_click" = "button1 = true")
```
`@click.native`would then simply be ~~`q_click.native` or  `at_click.native`~~ `q_click!native` or  `at_click!native`.

Furthermore I would encourage people to rather write
```
StippleUI.Button.button("Press me"; color = "secondary", loading = :button1, at_click = "button1 = true")
StippleUI.Button.button("Press me"; color = "secondary", loading = :button1, q_click = "button1 = true")
```

as this is at least very close to the original version `:loading = "button1"`.

An automatic replacement of "_" =>"-" seems very logical and prevents you from keeping an up-to-date list of possible keywords. As JS and in particular Quasar does not use the underscorecharacter in keywords, I think this is safe.
