### PR TITLE
Components: Uploader and raw quasar and vue elements

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1,8 +1,9 @@
 module API
 
-using Stipple
+using Stipple, StippleUI
+import Genie.Renderer.Html: HTMLString, normal_element
 
-export attributes
+export attributes, quasar, vue
 
 const ATTRIBUTES_MAPPINGS = Dict{String,String}(
   "autoclose" => "auto-close",
@@ -100,6 +101,31 @@ function attributes(kwargs::Vector{X},
   NamedTuple(attrs)
 end
 
+Genie.Renderer.Html.register_normal_element("q__elem", context = @__MODULE__)
+
+function quasar(elem::Symbol, args...;
+                wrap::Function = StippleUI.NO_WRAPPER,
+                kwargs...) where {T<:Stipple.ReactiveModel}
+  wrap() do
+    q__elem(args...;
+            attributes(
+              [Symbol(replace("$k", "_"=>"-")) => v for (k,v) in kwargs],
+              ATTRIBUTES_MAPPINGS
+            )...)
+  end |> x->replace(x, "q-elem"=>"q-$elem")
+end
+
+function vue(elem::Symbol, args...;
+                wrap::Function = StippleUI.NO_WRAPPER,
+                kwargs...) where {T<:Stipple.ReactiveModel}
+  wrap() do
+    q__elem(args...;
+            attributes(
+              [Symbol(replace("$k", "_"=>"-")) => v for (k,v) in kwargs],
+              ATTRIBUTES_MAPPINGS
+            )...)
+  end |> x->replace(x, "q-elem"=>"vue-$elem")
+end
 
 function __init__() :: Nothing
   Stipple.rendering_mappings(ATTRIBUTES_MAPPINGS)

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -5,11 +5,11 @@ import Genie.Renderer.Html: HTMLString, normal_element, template
 
 export space
 
-Genie.Renderer.Html.register_normal_element("q__separator", context = @__MODULE__)
+Genie.Renderer.Html.register_normal_element("q__space", context = @__MODULE__)
 
 function space(args...; wrap::Function = StippleUI.DEFAULT_WRAPPER, kwargs...)
   wrap() do
-    q__separator(args...; kwargs...)
+    q__space(args...; kwargs...)
   end
 end
 

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -64,8 +64,8 @@ include("Uploader.jl")
 
 #===#
 
-import .API.quasar, .API.vue
-export quasar, vue
+import .API: quasar, quasar_pure, vue, vue_pure
+export quasar, quasar_pure, vue, vue_pure
 @reexport using .Badge
 @reexport using .Banner
 @reexport using .BigNumber

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -6,6 +6,7 @@ import Stipple
 using Stipple.Reexport
 
 const DEFAULT_WRAPPER = Genie.Renderer.Html.template
+const NO_WRAPPER = f->f()
 
 #===#
 
@@ -62,6 +63,8 @@ include("Drawer.jl")
 
 #===#
 
+import .API.quasar, .API.vue
+export quasar, vue
 @reexport using .Badge
 @reexport using .Banner
 @reexport using .BigNumber

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -59,6 +59,7 @@ include("Toggle.jl")
 ############# new Elements ##################
 include("Layout.jl")
 include("Drawer.jl")
+include("Uploader.jl")
 
 
 #===#
@@ -86,6 +87,7 @@ export quasar, vue
 @reexport using .Space
 @reexport using .Table
 @reexport using .Toggle
+@reexport using .Uploader
 
 #===#
 

--- a/src/Uploader.jl
+++ b/src/Uploader.jl
@@ -1,0 +1,18 @@
+module Uploader
+
+using Genie, Stipple, StippleUI, StippleUI.API
+import Genie.Renderer.Html: HTMLString, normal_element
+
+export uploader
+
+Genie.Renderer.Html.register_normal_element("q__uploader", context = @__MODULE__)
+
+function uploader(args...;
+              wrap::Function = StippleUI.DEFAULT_WRAPPER,
+              kwargs...)
+  wrap() do
+    q__uploader(args...; kwargs...)
+  end
+end
+
+end


### PR DESCRIPTION
Add a raw quasar element for easy implementation of elements that are not yet included in  the `StippleUI.API` elements. (It was too tempting 😉)
 
This PR reflects the discussions in [Stipple PR18](https://github.com/GenieFramework/Stipple.jl/issues/18) and [Stipple PR19](https://github.com/GenieFramework/Stipple.jl/issues/19).

Example:

```
quasar(:img, src=:imageurl, spinner_color="white", style = "height: 140px; max-width: 150px")
```
returns
```
"<q-img :src=\"imageurl\" spinner-color=\"white\" style=\"height: 140px; max-width: 150px\"></q-img>"
```

