### PR TITLE
autoupload and multiple fix in docstring

### DIFF
--- a/src/Uploaders.jl
+++ b/src/Uploaders.jl
@@ -19,7 +19,7 @@ Stipple supplies a way for you to upload files through the `uploader` component.
 ### View
 
 ```julia-repl
-julia> uploader(label="Upload Image", :auto__upload, :multiple, method="POST", url="/upload", field__name="img")
+julia> uploader(label="Upload Image", autoupload=true, multiple=true, method="POST", url="/upload", field__name="img")
 ```
 
 -----------


### PR DESCRIPTION
The `:multiple` and `:auto__upload` functionality didn't work for me the one described in the rest of the docstring worked fine though.