### PR TITLE
Add type="number to numberfield FormInput

### DIFF
--- a/src/FormInputs.jl
+++ b/src/FormInputs.jl
@@ -117,8 +117,8 @@ function numberfield( label::String = "",
   q__input( [isa(content, Function) ? content() : join(content)],
             args...;
             kw(
-              [:label => label, :fieldname => fieldname, kwargs...],
-              Dict("fieldname" => "v-model.number", "type" => "number"))...
+              [:label => label, :fieldname => fieldname, :type => "number", kwargs...],
+              Dict("fieldname" => "v-model.number"))...
             )
 end
 

--- a/src/FormInputs.jl
+++ b/src/FormInputs.jl
@@ -118,7 +118,7 @@ function numberfield( label::String = "",
             args...;
             kw(
               [:label => label, :fieldname => fieldname, kwargs...],
-              Dict("fieldname" => "v-model.number"))...
+              Dict("fieldname" => "v-model.number", "type" => "number"))...
             )
 end
 


### PR DESCRIPTION
The change is to follow the Quasar guide: https://quasar.dev/vue-components/input#input-of-number-type
It enables the up/down arrows for number input: 
![image](https://user-images.githubusercontent.com/18605903/195518134-0590aed8-3c39-42a9-834b-a7449750aec5.png)
