### PR TITLE
add "markerlabels" => "marker-labels" line 110

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -107,6 +107,7 @@ const ATTRIBUTES_MAPPINGS = Dict{String,String}(
   "leftlabel" => "left-label",
   "manualfocus" => "manual-focus",
   "mapoptions" => "map-options",
+  "markerlabels" => "marker-labels",
   "maxfiles" => "max-files",
   "maxfilesize" => "max-file-size",
   "maxheight" => "max-height",


### PR DESCRIPTION
This PR aims at adding "markerlabels" => "marker-labels" at line 110 of API.jl.

This PR results from a discussion with abhi... on Genie Discord to set negative values in marker-labels.