### PR TITLE
support any Tables compatible type in StippleUI.Tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Colors = "0.12"

--- a/src/DatePickers.jl
+++ b/src/DatePickers.jl
@@ -128,11 +128,11 @@ Base.string(dp::DatePicker) = datepicker(dp.fieldname, dp.args...; dp.mask, dp.c
 
 # rendering and parsing internals
 
-function Stipple.render(dr::DateRange, _::Union{Symbol,Nothing} = nothing)
+function Stipple.render(dr::DateRange)
   Dict(:from => dr.start, :to => dr.stop)
 end
 
-function Stipple.render(vdr::Vector{DateRange}, _::Union{Symbol,Nothing} = nothing)
+function Stipple.render(vdr::Vector{DateRange})
   [ Dict(:from => dr.start, :to => dr.stop) for dr in vdr ]
 end
 

--- a/src/Ranges.jl
+++ b/src/Ranges.jl
@@ -205,7 +205,7 @@ function slider(range::AbstractRange{<:QRangeType},
   end
 end
 
-function Stipple.render(rd::RangeData{T}, fieldname::Union{Symbol,Nothing} = nothing) where {T}
+function Stipple.render(rd::RangeData{T}) where {T}
   Dict(:min => rd.range.start, :max => rd.range.stop)
 end
 

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -151,7 +151,8 @@ export quasar, quasar_pure, vue, vue_pure, xelem, xelem_pure, csscolors
 @reexport using .Spaces
 @reexport using .Spinners
 @reexport using .Splitters
-@reexport using .Tables
+@reexport using .QTables
+const Tables = QTables
 @reexport using .TabPanels
 @reexport using .Tabs
 @reexport using .Timelines


### PR DESCRIPTION
This PR fixes #97.
There shall be another PR that removes DataFrames dependency and moves stipple_parse methods to an extension.
Without DataFrames being loaded `DataTable()` should then resolve to `DataTable(Tables.table(Any[;;]))`