### PR TITLE
Add extension for DataFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,18 @@ version = "0.22.4"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[weakdeps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
+[extensions]
+StippleUIDataFramesExt = "DataFrames"
 
 [compat]
 Colors = "0.12"
@@ -24,6 +29,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataFrames"]

--- a/ext/StippleUIDataFrames.jl
+++ b/ext/StippleUIDataFrames.jl
@@ -1,0 +1,8 @@
+function StippleUI.QTables.DataTable()
+  DataTable(DataFrames.DataFrame())
+end
+
+function Stipple.convertvalue(target::Stipple.R{<:DataTable{DataFrames.DataFrame}}, d::AbstractDict)
+  df = Stipple.stipple_parse(DataFrames.DataFrame, d["data"])
+  DataTable(df[:, names(df) .!== "__id"], target.opts)
+end

--- a/ext/StippleUIDataFramesExt.jl
+++ b/ext/StippleUIDataFramesExt.jl
@@ -1,0 +1,18 @@
+module StippleUIDataFramesExt
+
+@static if isdefined(Base, :get_extension)
+  using DataFrames
+  using StippleUI
+  using StippleUI.Stipple
+end
+
+function StippleUI.QTables.DataTable()
+  DataTable(DataFrames.DataFrame())
+end
+
+function Stipple.convertvalue(target::Stipple.R{<:DataTable{DataFrames.DataFrame}}, d::AbstractDict)
+  df = Stipple.stipple_parse(DataFrames.DataFrame, d["data"])
+  DataTable(df[:, names(df) .!== "__id"], target.opts)
+end
+
+end

--- a/src/StippleUI.jl
+++ b/src/StippleUI.jl
@@ -170,10 +170,21 @@ export page_container # from Layouts
 
 #===#
 
+if !isdefined(Base, :get_extension)
+  using Stipple.Requires
+end
+
 function __init__()
   deps_routes()
   push!(Stipple.Layout.THEMES, theme)
   Stipple.deps!(@__MODULE__, deps)
+
+  @static if !isdefined(Base, :get_extension)
+    @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
+      # evaluate the code of the extension without the surrounding module
+      include(joinpath(@__DIR__, "..", "ext", "StippleUIDataFrames.jl"))
+    end
+  end
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,17 @@
-using StippleUI
 using Test
 
-@testset "StippleUI.jl" begin
+using StippleUI
+using Stipple
 
-    @test 1 == 1
+@testset "Extensions" begin
+    @test_throws MethodError DataTable()
+    using DataFrames
+    @test DataTable().data == DataFrame()
 
+    df = DataFrame(:a => [1, 2, 3], :b => ["a", "b", "c"])
+    dt = DataTable(df)
+    dict = render(DataTable(df))
+    dt_target = DataTable(deepcopy(df))
+    empty!(dt_target.data)
+    @test Stipple.convertvalue(R(dt_target), dict).data == dt.data
 end


### PR DESCRIPTION
This PR accounts for the new extension architecture in Julia 1.9, which replaces Requires.jl

Due to errors in using Revise together with Requires in Julia 1.8.5 I have added two different extension files for 1.9 and pre-1.9:

1.9:
- StippleUIDataFramesExt.jl

pre-1.9 (no modules, with Requires.jl):
- StippleUIDataFrames.jl

This PR is expected to fail until the corresponding PR https://github.com/GenieFramework/Stipple.jl/pull/209 in Stipple has been merged.