### PR TITLE
support julia expressions for some attributes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StippleUI"
 uuid = "a3c5d34a-b254-4859-a8fa-b86abb7e84a3"
 authors = ["Adrian Salceanu <e@essenciary.com>"]
-version = "0.23.0"
+version = "0.23.1"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -21,10 +21,11 @@ StippleUIDataFramesExt = "DataFrames"
 [compat]
 Colors = "0.12"
 DataFrames = "1"
+Dates = "1.6"
 Genie = "5"
 OrderedCollections = "1"
 PrecompileTools = "1"
-Stipple = "0.27.8"
+Stipple = "0.27.14"
 Tables = "1"
 julia = "1.6"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ using StippleUI
 makedocs(
     sitename = "SearchLight - Concise, secure, cross-platform query builder and ORM for Julia",
     format = Documenter.HTML(prettyurls = false),
+    warnonly = true,
     pages = [
         "Home" => "index.md",
         "StippleUI API" => [

--- a/src/Buttons.jl
+++ b/src/Buttons.jl
@@ -272,7 +272,7 @@ julia> btntoggle(:network, options = :networks, label="Social Networks", rounded
 """
 function btntoggle(fieldname::Symbol,
                 args...;
-                options::Symbol,
+                options::Union{Symbol, Vector{<:AbstractDict}},
                 kwargs...)
 
   q__btn__toggle(args...; kw(

--- a/src/Buttons.jl
+++ b/src/Buttons.jl
@@ -212,7 +212,7 @@ function btndropdown(args...; kwargs...)
 end
 
 """
-    btntoggle(fieldname::Symbol, args...; options::Symbol, kwargs...)
+    btntoggle(fieldname::Symbol, args...; options::Union{Symbol, Vector{<:AbstractDict}}, kwargs...)
 
 
 
@@ -249,7 +249,7 @@ julia> btntoggle(:network, options = :networks, label="Social Networks", rounded
       * `stack::Bool`- Stack icon and label vertically instead of on same line (like it is by default)
       * `stretch::Bool`- When used on flexbox parent, button will stretch to parent's height
 3. Model
-      * `options::Vector` - Available options that the user can select from. For best performance freeze the list of options ex. `options=[ 'BMW', 'Samsung Phone' ]`
+      * `options::Vector` - Available options that the user can select from. For best performance freeze the list of options ex. `options=[ "BMW", "Samsung Phone" ]`
       * `clearable::Bool` - Clears model on click of the already selected button
 4. State
       * `disable::Bool` - Put component in disabled mode
@@ -267,7 +267,7 @@ julia> btntoggle(:network, options = :networks, label="Social Networks", rounded
       * `glossy::Boolean` - Applies a glossy effect
       * `size::String` - Button size name or a CSS unit including unit name
       * `padding::String` - Apply custom padding (vertical [horizontal]); Size in CSS units, including unit name or standard size name (none|xs|sm|md|lg|xl); Also removes the min width and height when set
-      * `ripple::Union{Boolean, Dict}`` - Configure material ripple (disable it by setting it to 'false' or supply a Dict with `js_attr`, e.g. `js_attr(Stipple.opts(early = true, center = true, color = 'teal', keyCodes = []))`)
+      * `ripple::Union{Boolean, Dict}`` - Configure material ripple (disable it by setting it to 'false' or supply a Dict , e.g. `Stipple.opts(early = true, center = true, color = "teal", keyCodes = [])`)
       * `dense::Boolean` - Dense mode; occupies less space
 """
 function btntoggle(fieldname::Symbol,

--- a/src/ChatMessages.jl
+++ b/src/ChatMessages.jl
@@ -32,7 +32,7 @@ julia> @app begin
 julia> chatmessage("This is static text", name="stella", sent = true)
 julia> chatmessage(:textmsg1, name="dave", sent = true)
 julia> chatmessage(Symbol("[textmsg2]"), name="stella")
-julia> chatmessage(R"message.text", name = R"message.name", sent = R"message.sent", "", @recur("message in messages"))
+julia> chatmessage(R"message.text", name = R"message.name", sent = R"message.sent", "", @for("message in messages"))
 ```
 
 -----------

--- a/src/Forms.jl
+++ b/src/Forms.jl
@@ -29,7 +29,7 @@ julia> @vars FormModel begin
 ### View
 ```julia-repl
 julia> StippleUI.form(action = "/sub", method = "POST", [
-          textfield("What's your name *", :name, name = "name", @iif(:warin), :filled, hint = "Name and surname", "lazy-rules",
+          textfield("What's your name *", :name, name = "name", @if(:warin), :filled, hint = "Name and surname", "lazy-rules",
             rules = "[val => val && val.length > 0 || 'Please type something']"
           ),
           numberfield("Your age *", :age, name = "age", "filled", :lazy__rules,

--- a/src/Lists.jl
+++ b/src/Lists.jl
@@ -102,7 +102,7 @@ end
 # client side iteration
 function list(binding::Symbol, i::Item, args...; kwargs...)
   list(
-    Item(i, ["{{__b__}}"], @recur("__b__ in $binding"), key! = "__b__")
+    Item(i, ["{{__b__}}"], @for("__b__ in $binding"), key! = "__b__")
   )
 end
 

--- a/src/Selects.jl
+++ b/src/Selects.jl
@@ -6,7 +6,7 @@ import Genie.Renderer.Html: HTMLString, normal_element, select, template, regist
 register_normal_element("q__select", context = @__MODULE__)
 
 """
-    select(fieldname::Symbol, args...; options::Symbol, kwargs...)
+    select(fieldname::Symbol, args...; options::Union{Symbol, Vector}, kwargs...)
 
 
 
@@ -75,7 +75,7 @@ julia> select(:model, options= :networks, useinput=true, multiple=true, clearabl
       * `multiple::Bool` - Allow multiple selection; Model must be Array
       * `emitvalue::Bool` - Update model with the value of the selected option instead of the whole option
 5. Options
-      * `options::Vector` - Available options that the user can select from. For best performance freeze the list of options ex. `options=[ 'BMW', 'Samsung Phone' ]`
+      * `options::Vector` - Available options that the user can select from. For best performance freeze the list of options ex. `options = [ "BMW", "Samsung Phone" ]`
       * `optionvalue::String` - Property of option which holds the 'value'; If using a function then for best performance, reference it from your scope and do not define it inline ex. `optionvalue=modelNumber` `optionvalue="(item) => item === null ? null : item.modelNumber"`
       * `optionlabel::Union{String,Symbol}` - Property of option which holds the 'label'; If using a function then for best performance, reference it from your scope and do not define it inline ex. `optionlabel=itemName` `optionlabel="(item) => item === null ? null : item.itemName"`
       * `optiondisable::String` - Property of option which tells it's disabled; The value of the property must be a Boolean; If using a function then for best performance, reference it from your scope and do not define it inline ex. `optiondisable=cannotSelect` `optiondisable="(item) => item === null ? null : item.cannotSelect"`

--- a/src/Selects.jl
+++ b/src/Selects.jl
@@ -129,7 +129,7 @@ julia> select(:model, options= :networks, useinput=true, multiple=true, clearabl
 """
 function select(fieldname::Symbol,
                 args...;
-                options::Symbol,
+                options::Union{Symbol, Vector},
                 kwargs...)
 
   q__select(args...; kw(

--- a/src/Splitters.jl
+++ b/src/Splitters.jl
@@ -31,7 +31,7 @@ julia> splitter(:splitterM, style="height: 400px", [
                Quis praesentium cumque magnam odio iure quidem, quod illum numquam possimus
                obcaecati commodi minima assumenda consectetur culpa fuga nulla ullam. In, libero.",
               class = "q-my-md",
-              @recur(:"n in 20"), key! = "n")
+              @for(:"n in 20"), key! = "n")
           ])
         ]),
         template("", "v-slot:after", [
@@ -41,7 +41,7 @@ julia> splitter(:splitterM, style="height: 400px", [
                Quis praesentium cumque magnam odio iure quidem, quod illum numquam possimus
                obcaecati commodi minima assumenda consectetur culpa fuga nulla ullam. In, libero.",
               class = "q-my-md",
-              @recur(:"n in 20"), key! = "n")
+              @for(:"n in 20"), key! = "n")
           ])
         ])
        ])


### PR DESCRIPTION
This PR goes together with https://github.com/GenieFramework/Stipple.jl/pull/232 and is meant to support Julia expressions as values for attributes, mostly Dicts and Vectors.
Here, it is only about adding the respective types. The attribute handling is done in `Stipple.attributes()`.

@essenciary  or @PGimenez could you also go through the API and see where we should add types?