### PR TITLE
fix Documenter

### DIFF
--- a/docs/src/API/API.md
+++ b/docs/src/API/API.md
@@ -1,5 +1,5 @@
 ```@meta
-CurrentModule = API
+CurrentModule = StippleUI.API
 ```
 
 ```@docs
@@ -9,8 +9,5 @@ q__elem
 xelem
 quasar
 vue
-xelem_pure
-quasar_pure
-vue_pure
 csscolors
 ```

--- a/docs/src/API/layouts.md
+++ b/docs/src/API/layouts.md
@@ -1,5 +1,5 @@
 ```@meta
-CurrentModule = Layouts
+CurrentModule = StippleUI.Layouts
 ```
 
 ```@docs

--- a/docs/src/API/tables.md
+++ b/docs/src/API/tables.md
@@ -1,5 +1,5 @@
 ```@meta
-CurrentModule = Tables
+CurrentModule = StippleUI.Tables
 ```
 
 ```@docs


### PR DESCRIPTION
Currently there are many warnings from Documenter due to
- wrong module names
- missing doc strings
- deprecated functions in listings

@PGimenez , @essenciary , @AbhimanyuAryan Let's try to fix this step by step