### PR TITLE
Handle boolean values for val keyword correctly

### DIFF
--- a/src/Menus.jl
+++ b/src/Menus.jl
@@ -3,12 +3,12 @@ module Menus
 using Genie, Stipple, StippleUI, StippleUI.API
 import Genie.Renderer.Html: HTMLString, normal_element, register_normal_element
 
-export menu
+export qmenu
 
 register_normal_element("q__menu", context = @__MODULE__)
 
 """
-      menu(fieldname::Union{Symbol,Nothing} = nothing, args...; content::Union{String,Vector} = "", kwargs...)
+      menu(fieldname::Union{Symbol,Nothing}, args...; content::Union{String,Vector} = "", kwargs...)
 
 The `menu` component is a convenient way to show menus. Goes very well with `list` as dropdown content, but it’s by no means limited to it.   
 
@@ -19,7 +19,7 @@ The `menu` component is a convenient way to show menus. Goes very well with `lis
 ### View
 
 ```julia-repl
-julia> btn("Basic Menu", color="primary", [StippleUI.menu( [p("Hello")])
+julia> btn("Basic Menu", color="primary", [StippleUI.menu(nothing, [p("Hello")])])
 ```
 
 -----------
@@ -46,7 +46,7 @@ julia> btn("Basic Menu", color="primary", [StippleUI.menu( [p("Hello")])
       * `maxwidth::String` - The maximum width of the menu; Size in CSS units, including unit name ex. `16px` `2rem`
 """
 function menu(
-              fieldname::Union{Symbol,Nothing} = nothing,
+              fieldname::Symbol,
               args...;
               content::Union{String,Vector} = "",
               kwargs...)
@@ -56,11 +56,22 @@ function menu(
   end
 end
 
+function menu(
+      args...;
+      content::Union{String,Vector} = "",
+      kwargs...)
+
+  q__menu(args...; kw(kwargs)...) do
+    join(content)
+  end
+end
+
 function menu(content::Function,
-              fieldname::Union{Symbol,Nothing} = nothing,
               args...;
               kwargs...)
-  menu(label, fieldname, args...; content = content(), kwargs...)
+  menu(args...; content = content(), kwargs...)
 end
+
+const qmenu = menu
 
 end

--- a/src/Radios.jl
+++ b/src/Radios.jl
@@ -41,7 +41,10 @@ julia> radio("Polygon", :shape, val="polygon")
       * `keep-color::Bool` - Should the color (if specified any) be kept when checkbox is unticked?
 2. General
       * `tabindex::Union{Int, String}` - Tabindex HTML attribute value
+3. Model
+      * `fieldname::Symbol` - Name of the variable to bind to.
 4. Label
+      * `label::AbstractString` - Label
       * `leftlabel::Bool` - Label (if any specified) should be displayed on the left side of the checkbox
 5. State
       * `disable::Bool` - Put component in disabled mode
@@ -54,8 +57,10 @@ julia> radio("Polygon", :shape, val="polygon")
 function radio( label::AbstractString = "",
                 fieldname::Union{Symbol,Nothing} = nothing,
                 args...;
+                val = nothing,
                 kwargs...)
-  q__radio(args...; kw([:label => label, :fieldname => fieldname, kwargs...])...)
+  kw_val = val === nothing ? Dict() : Dict(:val => (val isa Bool ? js_attr(val) : val))
+  q__radio(args...; kw([:label => label, :fieldname => fieldname, kw_val..., kwargs...])...)
 end
 
 end


### PR DESCRIPTION
This PR fixes #57 by allowing supply of Bool values,

```julia
julia> radio("Bar plot", :show_bar, val = true)
"<q-radio :val=\"true\" label=\"Bar plot\" v-model=\"show_bar\"></q-radio>"
```
With this solution you are still allowed to write
```julia
julia> radio("Bar plot", :show_bar, val = "true")
"<q-radio val=\"true\" label=\"Bar plot\" v-model=\"show_bar\"></q-radio>"
```
which will attach the string "true"